### PR TITLE
Feature: Seperate Nextcloud Authentication

### DIFF
--- a/connect.js
+++ b/connect.js
@@ -1,6 +1,15 @@
 window.accounts = false
 window.server = false
 
+const defaultHeaders = new Headers({
+    "User-Agent": "Simple OTP Manager Browser Extension",
+    "OCS-APIRequest": "true",
+    "Content-Type": "application/x-www-form-urlencoded"
+});
+
+let requestHeaders = defaultHeaders
+  
+
 function showConnectError(text) {
     $("#server-input-error p").text(text)
     $("#server-input-error").show(50)
@@ -28,15 +37,114 @@ function getInputtedServerURL() {
 
 async function getOTPManagerAccounts(server) {
     try {
-        const response = await fetch(server+ "/index.php/apps/otpmanager/accounts")
+        const response = await fetch(server+ "/index.php/apps/otpmanager/accounts", {
+            headers: requestHeaders
+        })
         const jsonData = await response.json()
-        if (!response.ok || !jsonData.accounts) {
+        if (response.status === 401) {
+            showConnectError("Not authenticated, please connect again to login.")
+            deleteSavedNCLogin()
+            return false
+        } else if (!response.ok || !jsonData.accounts) {
             console.log("Failed to load accounts at: ", server+ "/index.php/apps/otpmanager/accounts")
+            showConnectError("Could not load accounts from OTP Manager. Please check the server is healthy and the OTP Manager extension is installed.")
             return false
         }
         return jsonData.accounts
     } catch {
         console.log("Error loading: ", server+ "/index.php/apps/otpmanager/accounts")
+        showConnectError("Could not load accounts from OTP Manager. Please check the server is healthy and the OTP Manager extension is installed.")
+        return false
+    }
+}
+
+function getSavedNCLogin() {
+    const login = JSON.parse(localStorage.getItem("otpmanager-browser_NClogin"))
+    if (login && login.username && login.appPassword) {
+        return login
+    }
+    return false
+}
+
+async function deleteSavedNCLogin() {
+    // Try to delete from Nextcloud server
+    try {
+        const response = await fetch(window.server+ "index.php/ocs/v2.php/core/apppassword", {
+            method: "DELETE",
+            headers: requestHeaders
+        })
+        if (response.ok) {
+            console.log("appPassword deleted")
+        } else {
+            console.log("appPassword failed to delete")
+        }
+    } catch {
+        console.log("Error deleting: ", window.server+ "/index.php/ocs/v2.php/core/apppassword")
+    }
+    // Delete from localstorage
+    localStorage.removeItem("otpmanager-browser_NClogin")
+    // Delete from headers we're currently using
+    requestHeaders = defaultHeaders
+}
+
+async function setSavedNCLogin(pollJSON) {
+    const poll = JSON.parse(pollJSON)
+
+    try {
+        const response = await fetch(poll.endpoint, {
+            method: "POST",
+            headers: requestHeaders,
+            body: "token="+ poll.token
+        })
+        const jsonData = await response.json()
+        // 404 means authentication wasn't completed for this token
+        if (response.status === 404) {
+            showConnectError("Last Nextcloud login not complete, please try again")
+            localStorage.removeItem("otpmanager-browser_NCloginPoll")
+            return false
+        } else if (!response.ok || !jsonData.loginName || !jsonData.appPassword) {
+            console.log("Failed to poll login token at: ", poll.endpoint)
+            return false
+        }
+
+        // We have a username and password
+        localStorage.setItem("otpmanager-browser_NClogin", JSON.stringify({username: jsonData.loginName, appPassword: jsonData.appPassword}))
+        localStorage.removeItem("otpmanager-browser_NCloginPoll")
+        return true
+    } catch {
+        console.log("Error loading: ", poll.endpoint)
+        return false
+    }
+}
+
+async function startNClogin(server) {
+    // Request login v2 from NC
+    try {
+        const response = await fetch(server+ "/index.php/login/v2", {
+            method: "POST",
+            headers: requestHeaders
+        })
+        const jsonData = await response.json()
+        if (!response.ok || !jsonData.poll || !jsonData.login) {
+            console.log("Failed to start login process at: ", server+ "/index.php/login/v2")
+            return false
+        }
+
+        // Save the poll token/URL to use later
+        localStorage.setItem("otpmanager-browser_NCloginPoll", JSON.stringify(jsonData.poll))
+
+        // Prompt the user to open the login page
+        $("#server-input-loginlink").show(50)
+        $("#server-input-loginlink button").on("click", function() {
+            chrome.tabs.create({
+                url: jsonData.login,
+            })
+        })
+        console.log("Login URL", jsonData.login)
+
+        return true
+    } catch {
+        console.log("Error loading: ", server+ "/index.php/login/v2")
         return false
     }
 }
@@ -85,17 +193,39 @@ async function connectToNextcloud(useSaved) {
         return
     }
 
+
+    // Save URL as it's an NC server
+    localStorage.setItem("otpmanager-browser_server", server)
+    window.server = server
+
+    // Check if we have a v2 login flow to check
+    if (localStorage.getItem("otpmanager-browser_NCloginPoll")) {
+        // If we do then let's retreive our credentials
+        const loginSaved = await setSavedNCLogin(localStorage.getItem("otpmanager-browser_NCloginPoll"))
+        if (!loginSaved) {
+            return false
+        }
+    }
+
+    // Check if we have login details
+    let login = getSavedNCLogin()
+    if (useSaved && login) {
+        // Add login details to our headers
+        requestHeaders.set('Authorization', 'Basic ' + btoa(login.username + ":" + login.appPassword));
+    } else {
+        // We don't have NC login details
+        if (!await startNClogin(server)) {
+            showConnectError("Failed to start login flow")
+        }
+        return
+    }
+
     // Try and connect to OTP Manager
     const accounts = await getOTPManagerAccounts(server)
     if (!accounts) {
-        showConnectError("Could not load accounts from OTP Manager. Please check you are logged into Nextcloud in this browser and the OTP Manager extension is installed.")
         return
     }
     window.accounts = accounts
-
-    // Save URL as we've been successful
-    localStorage.setItem("otpmanager-browser_server", server)
-    window.server = server
 
     // We've now got something saved so let the user "logout"
     $("#sign-out-button").show(300)
@@ -108,6 +238,7 @@ async function connectToNextcloud(useSaved) {
 function signOut() {
     localStorage.removeItem("otpmanager-browser_server")
     localStorage.removeItem("otpmanager-browser_saved_password")
+    deleteSavedNCLogin()
     location.reload()
 
 }

--- a/password.js
+++ b/password.js
@@ -46,7 +46,13 @@ async function checkPassword(useSaved) {
 
     // Check password against server & store IV
     try {
-        const response = await fetch(window.server+ "/index.php/apps/otpmanager/password/check", {method: "POST", headers: {"Content-Type": "application/json",}, body: JSON.stringify({password: pass})})
+        let headers = requestHeaders
+        headers.set("Content-Type", "application/json")
+        const response = await fetch(window.server+ "/index.php/apps/otpmanager/password/check", {
+            method: "POST",
+            headers: requestHeaders,
+            body: JSON.stringify({password: pass})
+        })
         const jsonData = await response.json()
         if (!response.ok) {
             if (response.status === 400) {

--- a/popup.html
+++ b/popup.html
@@ -115,10 +115,14 @@
             </div>
 
             <div class="ui hidden message" id="server-input-loginlink">
-                <!-- <p>Please click the button below and allow access to your Nextcloud server</p> -->
-                <button class="ui fluid teal right labeled icon button">
+                <button class="ui fluid teal right labeled icon button" id="server-input-nc-login-button">
                     <i class="sign in alternate icon"></i>
                     Login to Nextcloud
+                </button>
+                <div class="ui horizontal divider">Or</div>
+                <button class="ui fluid right labeled icon button" id="server-input-nc-copy-button">
+                    <i class="copy icon"></i>
+                    Copy Login Link
                 </button>
             </div>
         </div>

--- a/popup.html
+++ b/popup.html
@@ -113,6 +113,14 @@
             <div class="ui negative hidden message" id="server-input-error">
                 <p></p>
             </div>
+
+            <div class="ui hidden message" id="server-input-loginlink">
+                <!-- <p>Please click the button below and allow access to your Nextcloud server</p> -->
+                <button class="ui fluid teal right labeled icon button">
+                    <i class="sign in alternate icon"></i>
+                    Login to Nextcloud
+                </button>
+            </div>
         </div>
 
 


### PR DESCRIPTION
Resolves #1 

This change stops sending credentials with requests and instead gets the user to use Login Flow v2 to get an apppassword which is then used to authenticate every time. The apppassword is deleted from the server if the user clicks the logout icon.