### PR TITLE
fix: sort by 'created' crashes with TypeError (created_at vs createdAt)

### DIFF
--- a/displayotp.js
+++ b/displayotp.js
@@ -25,9 +25,9 @@ function sortAccounts(on, order) {
 
       case "created":
         if (order == "asc") {
-          window.accounts.sort((a, b) => a.created_at.localeCompare(b.created_at))
+          window.accounts.sort((a, b) => (a.createdAt || "").localeCompare(b.createdAt || ""))
         } else {
-          window.accounts.sort((a, b) => b.created_at.localeCompare(a.created_at))
+          window.accounts.sort((a, b) => (b.createdAt || "").localeCompare(a.createdAt || ""))
         }
         return true;
 


### PR DESCRIPTION
## Bug

When the user has sort set to "Created date", opening the extension popup throws:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'localeCompare')
    at displayotp.js:28:55
    at Array.sort
    at sortAccounts (displayotp.js:28:27)
    at displayOtp (displayotp.js:162:5)
    at checkPassword (password.js:91:5)
```

The extension popup shows empty (no OTP codes) even though data exists in Nextcloud.

## Root cause

The `sortAccounts` function accesses `a.created_at` (snake_case), but the OTP Manager Nextcloud app v1.0+ API returns the field as `createdAt` (camelCase). This makes `a.created_at` undefined, and calling `.localeCompare()` on it crashes.

## Fix

Changed `a.created_at` / `b.created_at` → `a.createdAt` / `b.createdAt` to match the API response format. Also added `|| ""` guard for accounts where `createdAt` may be null.

## Workaround (until this is merged)

In the extension DevTools console, reset the sort setting:
```js
let s = JSON.parse(localStorage.getItem("otpmanager-browser_settings") || "{}");
s.sortOn = "name";
localStorage.setItem("otpmanager-browser_settings", JSON.stringify(s));
```
Then reopen the popup.